### PR TITLE
silence the "j" input

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 5. [Contributors](#contributors)
 
 ## Description
+Jharttech:  I added some lines of perl to the pwnagotchi-viewer-next file to silence the "j" input to keep the screen focus from switching between tty1 and the viewer.  This was causing the screen to flash or flicker between the two continuously.
+
+I also added an extra flag to the fbi (linux framebuffer imageviewer) tool on line 18 to force refresh every second.  If you desire a different forced refresh you can try to adjust the -t 1 value.  More info on fbi <a href="https://linux.die.net/man/1/fbi">Here</a>. 
+
 
 It's a Proof of Concept to display [Pwnagotchi](https://pwnagotchi.ai/) output via HDMI.
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 5. [Contributors](#contributors)
 
 ## Description
+
 Jharttech:  I added some lines of perl to the pwnagotchi-viewer-next file to silence the "j" input to keep the screen focus from switching between tty1 and the viewer.  This was causing the screen to flash or flicker between the two continuously.
 
-I also added an extra flag to the fbi (linux framebuffer imageviewer) tool on line 18 to force refresh every second.  If you desire a different forced refresh you can try to adjust the -t 1 value.  More info on fbi <a href="https://linux.die.net/man/1/fbi">Here</a>. 
-
+I also added an extra flag to the fbi (linux framebuffer imageviewer) tool on line 18 to force refresh every second.  If you desire a different forced refresh you can try to adjust the -t 1 value.  More info on fbi [Here](https://linux.die.net/man/1/fbi).
 
 It's a Proof of Concept to display [Pwnagotchi](https://pwnagotchi.ai/) output via HDMI.
 

--- a/pwnagotchi-viewer
+++ b/pwnagotchi-viewer
@@ -15,7 +15,7 @@ ALIAS_FILE_2=pwnagotchi-alias-2.png
 trap "pkill fbi; exit" SIGINT SIGTERM
 
 main() {
-     fbi -T 1 -d /dev/fb0 -a -noverbose -cachemem 0 $FILE $ALIAS_FILE_1 $ALIAS_FILE_2
+     fbi -T 1 -t 1 -d /dev/fb0 -a -noverbose -cachemem 0 $FILE $ALIAS_FILE_1 $ALIAS_FILE_2
 }
 
 cd "$DIR" || exit

--- a/pwnagotchi-viewer-next
+++ b/pwnagotchi-viewer-next
@@ -1,5 +1,7 @@
 #!/usr/bin/env perl
 
+use Term::ReadKey;
+
 $TIOCSTI = 0x5412;
 $pid = `pgrep -n fbi`;
 chomp($pid);
@@ -7,3 +9,16 @@ $tty = "/proc/$pid/fd/0";
 $char = "j";
 open($fh, ">", $tty);
 ioctl($fh, $TIOCSTI, $char)
+
+
+ReadMode('noecho');   # Turn off echo
+ReadMode('raw');      # Set raw mode to prevent any signal handling
+
+while (1) {
+    if (defined(my $key = ReadKey(-1))) {   # Read a single character
+        # Discard the input
+    }
+    else {
+        last;   # Exit the loop when there's no more input
+    }
+}


### PR DESCRIPTION
@jharttech:
> I added some lines of perl to the pwnagotchi-viewer-next file to silence the "j" input to keep the screen focus from switching between tty1 and the viewer.  This was causing the screen to flash or flicker between the two continuously.
> 
> I also added an extra flag to the fbi (linux framebuffer imageviewer) tool on line 18 to force refresh every second.  If you desire a different forced refresh you can try to adjust the -t 1 value.  More info on fbi <a href="https://linux.die.net/man/1/fbi">Here</a>. 